### PR TITLE
hotfix/OTC-750: Adding missing props

### DIFF
--- a/src/components/ClaimAdministratorFormPanel.js
+++ b/src/components/ClaimAdministratorFormPanel.js
@@ -92,6 +92,7 @@ const ClaimAdministratorFormPanel = (props) => {
               <PublishedComponent
                 pubRef="location.HealthFacilityPicker"
                 value={edited?.healthFacility}
+                district={edited?.districts}
                 required
                 module="admin"
                 readOnly={readOnly}


### PR DESCRIPTION
During the [OTC-750](https://openimis.atlassian.net/browse/OTC-750) investigation, I fixed the HFPicker in `ClaimAdministratorFormPanel.js`. Because of the lack of district prop, GQL query could not fetch the appropriate health facilities. Moreover, it is synchronized with the picker in New User form now.