### PR TITLE
OP-949: Display users attached to restricted regions

### DIFF
--- a/src/components/UserSearcher.js
+++ b/src/components/UserSearcher.js
@@ -54,7 +54,6 @@ class UserSearcher extends Component {
 
   fetch = (params) => {
     this.setState({ params });
-    console.log("params", params);
     if (this.props.fetchedUserLocation) {
       this.props.fetchUsersSummaries(this.props.modulesManager, params);
     }
@@ -76,8 +75,6 @@ class UserSearcher extends Component {
   };
 
   filtersToQueryParams = (state) => {
-    console.log("state", state);
-    console.log("propsy", this.props);
     const prms = Object.keys(state.filters)
       .filter((contrib) => !!state.filters[contrib].filter)
       .map((contrib) => state.filters[contrib].filter);
@@ -94,7 +91,6 @@ class UserSearcher extends Component {
     if (this.props.fetchedUserLocation) {
       this.setRegionIds(prms);
     }
-    console.log("prms", prms);
     return prms;
   };
 


### PR DESCRIPTION
[OP-949](https://openimis.atlassian.net/browse/OP-949)

When I logged out from the admin without any of location restrictions and logged in as an admin with some, I've got the permissions from the previous user until page refresh. In scope of this ticket, I fixed this issue, now it displays users attatched to restricted region, page refresh is not needed.

[OP-949]: https://openimis.atlassian.net/browse/OP-949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[OP-949]: https://openimis.atlassian.net/browse/OP-949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ