### PR TITLE
OP-1064: Switch buttons always visible, make user roles unique

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -193,7 +193,7 @@ export function fetchUser(mm, userId, clientMutationId) {
               languageId
               lastName
               otherNames
-              roles { id name }
+              roles { id name isSystem}
               healthFacility ${mm.getProjection("location.HealthFacilityPicker.projection")}
               validityFrom
               validityTo

--- a/src/components/ClaimAdministratorFormPanel.js
+++ b/src/components/ClaimAdministratorFormPanel.js
@@ -65,7 +65,7 @@ const ClaimAdministratorFormPanel = (props) => {
       <Grid item xs={12} className={classes.title}>
         <Grid container justifyContent="space-between" alignItems="center">
           <Typography variant="h6">{formatMessage("title")}</Typography>
-          {(!edited.id || !isEnabled) && (
+          {(edited || !isEnabled) && (
             <Switch
               color="secondary"
               disabled={readOnly}

--- a/src/components/EnrolmentOfficerFormPanel.js
+++ b/src/components/EnrolmentOfficerFormPanel.js
@@ -46,7 +46,6 @@ const EnrolmentOfficerFormPanel = (props) => {
     { system_id: OFFICER_ROLE_IS_SYSTEM },
   );
   const isValid = !isLoading;
-
   useEffect(() => {
     toggleUserRoles(
       edited, 
@@ -74,7 +73,7 @@ const EnrolmentOfficerFormPanel = (props) => {
       <Grid item xs={12} className={classes.title}>
         <Grid container justifyContent="space-between" alignItems="center">
           <Typography variant="h6">{formatMessage("title")}</Typography>
-          {(!edited.id || !isEnabled) && (
+          {(edited || !isEnabled) && (
             <Switch
               color="secondary"
               disabled={readOnly}

--- a/src/components/pickers/UserRolesPicker.js
+++ b/src/components/pickers/UserRolesPicker.js
@@ -33,7 +33,7 @@ const UserRolesPicker = ({
   );
 
   const roles = data?.role?.edges.map((edge) => edge.node) ?? [];
-  const uniqueValues = [...new Map(value?.map((role) => [role.isSystem, role])).values()];
+  const uniqueValues = [...new Map(value?.map((role) => [role.id, role])).values()];
 
   return (
     <Autocomplete

--- a/src/components/pickers/UserRolesPicker.js
+++ b/src/components/pickers/UserRolesPicker.js
@@ -32,6 +32,9 @@ const UserRolesPicker = ({
     { str: searchString },
   );
 
+  const roles = data?.role?.edges.map((edge) => edge.node) ?? [];
+  const uniqueValues = [...new Map(value?.map((role) => [role.isSystem, role])).values()];
+
   return (
     <Autocomplete
       multiple={multiple}
@@ -42,9 +45,9 @@ const UserRolesPicker = ({
       withLabel={withLabel}
       withPlaceholder={withPlaceholder}
       readOnly={readOnly}
-      options={data?.role?.edges.map((edge) => edge.node) ?? []}
+      options={roles}
       isLoading={isLoading}
-      value={value}
+      value={uniqueValues}
       getOptionLabel={(o) => o?.name}
       onChange={(option) => onChange(option, option?.name)}
       filterOptions={filterOptions}


### PR DESCRIPTION
[OP-1064](https://openimis.atlassian.net/browse/OP-1064)

In scope of this ticket, I dealt with the disapearing switch buttons. I made them always visible as we settled in the daily. Moreover, I made a user roles unique. This prevent adding the same role multiple times. Now, I can edit the user and manipulate his roles by using switchs as well as input. It makes the whole form more user-friendly.

[OP-1064]: https://openimis.atlassian.net/browse/OP-1064?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ