### PR TITLE
OTC-884: Disabled save button in user form fix

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -295,13 +295,19 @@ export function usernameValidationCheck(mm, variables) {
     }
     `,
     variables,
-    `USERNAME_VALIDATION_FIELDS`,
+    `USERNAME_FIELDS_VALIDATION`,
   );
 }
 
 export function usernameValidationClear() {
   return (dispatch) => {
-    dispatch({ type: `USERNAME_VALIDATION_FIELDS_CLEAR` });
+    dispatch({ type: `USERNAME_FIELDS_VALIDATION_CLEAR` });
+  };
+}
+
+export function setUsernameValid() {
+  return (dispatch) => {
+    dispatch({ type: "USERNAME_FIELDS_VALIDATION_SET_VALID" });
   };
 }
 

--- a/src/components/UserMasterPanel.js
+++ b/src/components/UserMasterPanel.js
@@ -4,7 +4,7 @@ import { Grid, Divider, Typography } from "@material-ui/core";
 import { withModulesManager, useTranslations, TextInput, PublishedComponent, ValidatedTextInput } from "@openimis/fe-core";
 import { connect } from "react-redux";
 import { CLAIM_ADMIN_USER_TYPE, ENROLMENT_OFFICER_USER_TYPE } from "../constants";
-import { usernameValidationCheck, usernameValidationClear, clearUser} from "../actions";
+import { usernameValidationCheck, usernameValidationClear, setUsernameValid } from "../actions";
 
 const styles = (theme) => ({
   tableTitle: theme.table.title,
@@ -42,6 +42,7 @@ const UserMasterPanel = (props) => {
           validationError={usernameValidationError}
           action={usernameValidationCheck}
           clearAction={usernameValidationClear}
+          setValidAction={setUsernameValid}
           module="admin"
           label="user.username"
           codeTakenLabel="user.usernameAlreadyTaken"

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -288,7 +288,7 @@ function reducer(
         fetching_obligatory_eo_fields: false,
         errorL1s: formatServerError(action.payload),
       };
-    case "USERNAME_VALIDATION_FIELDS_REQ":
+    case "USERNAME_FIELDS_VALIDATION_REQ":
       return {
         ...state,
         validationFields: {
@@ -300,7 +300,7 @@ function reducer(
           },
         },
       };
-    case "USERNAME_VALIDATION_FIELDS_RESP":
+    case "USERNAME_FIELDS_VALIDATION_RESP":
       return {
         ...state,
         validationFields: {
@@ -312,7 +312,7 @@ function reducer(
           },
         },
       };
-    case "USERNAME_VALIDATION_FIELDS_ERR":
+    case "USERNAME_FIELDS_VALIDATION_ERR":
       return {
         ...state,
         validationFields: {
@@ -324,7 +324,7 @@ function reducer(
           },
         },
       };
-    case "USERNAME_VALIDATION_FIELDS_CLEAR":
+    case "USERNAME_FIELDS_VALIDATION_CLEAR":
       return {
         ...state,
         validationFields: {
@@ -332,6 +332,18 @@ function reducer(
           username: {
             isValidating: true,
             isValid: false,
+            validationError: null,
+          },
+        },
+      };
+    case "USERNAME_FIELDS_VALIDATION_SET_VALID":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          username: {
+            isValidating: false,
+            isValid: true,
             validationError: null,
           },
         },


### PR DESCRIPTION
[OTC-884](https://openimis.atlassian.net/browse/OTC-884)

In scope of this ticket, I corrected the state of _isValid_ by adding an extra action, which sets the state properly when we're editing a username for the first time. Moreover, there was an issue when we paste an invalid username and then revert it using CTRL+Z to the valid one, save button was anyway blocked although saving should be possbile. After the fix, it works as intended.

[OTC-884]: https://openimis.atlassian.net/browse/OTC-884?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ