### PR TITLE
OTC-897: Unlock save when email is not given

### DIFF
--- a/src/components/UserMasterPanel.js
+++ b/src/components/UserMasterPanel.js
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useEffect } from "react";
 import { connect } from "react-redux";
 
 import { withTheme, withStyles } from "@material-ui/core/styles";
@@ -62,6 +62,9 @@ const UserMasterPanel = (props) => {
 
   const shouldValidateEmail = (inputValue) => {
     const shouldBeValidated = inputValue !== savedUserEmail;
+    if (!inputValue) {
+      return false;
+    }
     return shouldBeValidated;
   };
 


### PR DESCRIPTION
[OTC-987](https://openimis.atlassian.net/browse/OTC-897)

In scope of this ticket, I fixed the email validation. Before this change, the user form does not allow to create new user without an action with e-mail field. Now, it works like intended - there is no need to take any additional actions.