### PR TITLE
OTC-875: No need to interact with form to update user roles

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -99,11 +99,11 @@ export const toggleUserRoles = (edited, data, isValid, isEnabled, hasRole, onEdi
   if (isValid && isEnabled && !hasRole) {
     roles.push(role);
     edited.roles = roles;
-    onEditedChanged(edited);
+    onEditedChanged({ ...edited });
   } else if (isValid && !isEnabled) {
     const filteredRoles = roles.filter((tempRole) => tempRole.isSystem !== roleIsSystem);
     edited.roles = filteredRoles;
-    onEditedChanged(edited);
+    onEditedChanged({ ...edited });
   }
 };
 


### PR DESCRIPTION
[OTC-875](https://openimis.atlassian.net/browse/OTC-875)

In scope of this ticket, I fixed updating the page when we manipulate user roles by using switch buttons. 

[OTC-875]: https://openimis.atlassian.net/browse/OTC-875?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ