### PR TITLE
OTC-904: Wrong userTypes in mutation input fix

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -7,7 +7,7 @@ import {
   dispatchMutationErr,
   dispatchMutationReq,
 } from "@openimis/fe-core";
-import { getUserTypes, mapQueriesUserToStore } from "./utils";
+import { checkRolesAndGetUserTypes, mapQueriesUserToStore } from "./utils";
 
 function reducer(
   state = {
@@ -98,7 +98,7 @@ function reducer(
           fetched: action.meta,
           items: parseData(action.payload.data.users).map((user) => ({
             ...user,
-            userTypes: getUserTypes(user),
+            userTypes: checkRolesAndGetUserTypes(user),
           })),
           error: formatGraphQLError(action.payload),
         },

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,22 +1,42 @@
 import { decodeId } from "@openimis/fe-core";
-import { CLAIM_ADMIN_USER_TYPE, INTERACTIVE_USER_TYPE, ENROLMENT_OFFICER_USER_TYPE } from "./constants";
+import {
+  CLAIM_ADMIN_USER_TYPE,
+  INTERACTIVE_USER_TYPE,
+  ENROLMENT_OFFICER_USER_TYPE,
+  CLAIM_ADMIN_IS_SYSTEM,
+  OFFICER_ROLE_IS_SYSTEM,
+} from "./constants";
 
-export const getUserTypes = (user) => {
-  // We force from now on all users to be interactive
-  const userTypes = [INTERACTIVE_USER_TYPE];
-  if (user.officer?.id) {
-    userTypes.push(ENROLMENT_OFFICER_USER_TYPE);
+const addUserType = (user, userType) => {
+  if (!user.userTypes.includes(userType)) {
+    user.userTypes = [...user.userTypes, userType];
   }
-  if (user.claimAdmin?.id) {
-    userTypes.push(CLAIM_ADMIN_USER_TYPE);
-  }
-  return userTypes;
 };
+
+export function checkRolesAndGetUserTypes(user) {
+  if (!user) return console.warn("User not provided in checkRolesAndGetUserTypes function!");
+
+  const tempUser = user;
+  const initialUserTypes = [INTERACTIVE_USER_TYPE];
+
+  if (!tempUser.roles) {
+    tempUser.userTypes = initialUserTypes;
+  }
+
+  if (tempUser.roles?.some((role) => role.isSystem === CLAIM_ADMIN_IS_SYSTEM)) {
+    addUserType(tempUser, CLAIM_ADMIN_USER_TYPE);
+  }
+
+  if (tempUser.roles?.some((role) => role.isSystem === OFFICER_ROLE_IS_SYSTEM)) {
+    addUserType(tempUser, ENROLMENT_OFFICER_USER_TYPE);
+  }
+  return tempUser.userTypes;
+}
 
 export const mapQueriesUserToStore = (u) => {
   // TODO: make this more generic
   u.hasLogin = false;
-  u.userTypes = getUserTypes(u);
+  u.userTypes = checkRolesAndGetUserTypes(u);
   if (u.iUser) {
     u.hasLogin = true;
     u.lastName = u.iUser.lastName;


### PR DESCRIPTION
[OTC-904](https://openimis.atlassian.net/browse/OTC-904)

In scope of this ticket, I changed the getUserTypes function, which now depends on the user roles. It allows me to send an input with proper UserTypes included.

[OTC-904]: https://openimis.atlassian.net/browse/OTC-904?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ