### PR TITLE
OTC-757: Clearing pagination state if entered the UsersPage

### DIFF
--- a/src/components/UserSearcher.js
+++ b/src/components/UserSearcher.js
@@ -176,7 +176,7 @@ class UserSearcher extends Component {
           errorItems={errorUsers}
           contributionKey={USER_SEARCHER_CONTRIBUTION_KEY}
           tableTitle={formatMessageWithValues(intl, "admin.user", "userSummaries", {
-            count: usersPageInfo.totalCount.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","),
+            count: usersPageInfo.totalCount?.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ","),
           })}
           fetch={this.fetch}
           rowIdentifier={(r) => r.uuid}

--- a/src/constants.js
+++ b/src/constants.js
@@ -20,6 +20,7 @@ export const ENROLMENT_OFFICER_USER_TYPE = "OFFICER";
 export const OFFICER_ROLE_IS_SYSTEM = 1;
 export const CLAIM_ADMIN_USER_TYPE = "CLAIM_ADMIN";
 export const CLAIM_ADMIN_IS_SYSTEM = 256;
+export const MODULE_NAME = "user";
 
 export const USER_TYPES = (rights) => {
   const baseTypes = [INTERACTIVE_USER_TYPE];

--- a/src/pages/UsersPage.js
+++ b/src/pages/UsersPage.js
@@ -1,12 +1,22 @@
 import React, { Component } from "react";
+import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
+
 import { Fab } from "@material-ui/core";
 import AddIcon from "@material-ui/icons/Add";
 import { withTheme, withStyles } from "@material-ui/core/styles";
-import { historyPush, withModulesManager, withHistory, withTooltip, formatMessage } from "@openimis/fe-core";
-import UserSearcher from "../components/UserSearcher";
+
+import {
+  historyPush,
+  withModulesManager,
+  withHistory,
+  withTooltip,
+  formatMessage,
+  clearCurrentPaginationPage,
+} from "@openimis/fe-core";
 import { RIGHT_USER_ADD } from "../constants";
+import UserSearcher from "../components/UserSearcher";
 
 const styles = (theme) => ({
   page: theme.page,
@@ -20,6 +30,12 @@ class UsersPage extends Component {
 
   onAdd = () => {
     historyPush(this.props.modulesManager, this.props.history, "admin.userNew");
+  };
+
+  componentDidMount = () => {
+    const moduleName = "user";
+    const { module } = this.props;
+    if (module !== moduleName) this.props.clearCurrentPaginationPage();
   };
 
   render() {
@@ -43,8 +59,13 @@ class UsersPage extends Component {
 
 const mapStateToProps = (state) => ({
   rights: state.core?.user?.i_user?.rights ?? [],
+  module: state.core?.savedPagination?.module,
 });
 
+const mapDispatchToProps = (dispatch) => bindActionCreators({ clearCurrentPaginationPage }, dispatch);
+
 export default injectIntl(
-  withModulesManager(withHistory(connect(mapStateToProps)(withTheme(withStyles(styles)(UsersPage))))),
+  withModulesManager(
+    withHistory(connect(mapStateToProps, mapDispatchToProps)(withTheme(withStyles(styles)(UsersPage)))),
+  ),
 );

--- a/src/pages/UsersPage.js
+++ b/src/pages/UsersPage.js
@@ -15,7 +15,7 @@ import {
   formatMessage,
   clearCurrentPaginationPage,
 } from "@openimis/fe-core";
-import { RIGHT_USER_ADD } from "../constants";
+import { RIGHT_USER_ADD, MODULE_NAME } from "../constants";
 import UserSearcher from "../components/UserSearcher";
 
 const styles = (theme) => ({
@@ -33,9 +33,8 @@ class UsersPage extends Component {
   };
 
   componentDidMount = () => {
-    const moduleName = "user";
     const { module } = this.props;
-    if (module !== moduleName) this.props.clearCurrentPaginationPage();
+    if (module !== MODULE_NAME) this.props.clearCurrentPaginationPage();
   };
 
   render() {


### PR DESCRIPTION
[OTC-757](https://openimis.atlassian.net/browse/OTC-757)

Changes:
- Implementation of optional chaining in UserSearcher to avoid form crashes in exact situations.
- Clearing pagination state if entered the UsersPage.
- Implementation of the logic responsible for going back from edit form and keeping the same page which was before.

[OTC-757]: https://openimis.atlassian.net/browse/OTC-757?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ