### PR TITLE
OTC-887: Display proper information when validating email

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -345,3 +345,9 @@ export function setUserEmailValid() {
     dispatch({ type: "USER_EMAIL_FIELDS_VALIDATION_SET_VALID" });
   };
 }
+
+export function saveEmailFormatValidity(isFormatInvalid) {
+  return (dispatch) => {
+    dispatch({ type: "USER_EMAIL_FORMAT_VALIDATION_CHECK", payload: { data: { isFormatInvalid } } });
+  };
+}

--- a/src/components/UserForm.js
+++ b/src/components/UserForm.js
@@ -27,9 +27,9 @@ import {
   clearUser,
   fetchUserMutation,
   fetchRegionDistricts,
-  clearRegionDistricts,
   fetchObligatoryUserFields,
-  fetchObligatoryEnrolmentOfficerFields, fetchUsernameLength,
+  fetchObligatoryEnrolmentOfficerFields,
+  fetchUsernameLength,
 } from "../actions";
 import UserMasterPanel from "./UserMasterPanel";
 
@@ -140,6 +140,7 @@ class UserForm extends Component {
         user.username &&
         this.props.isUserNameValid === true &&
         this.props.isUserEmailValid === true &&
+        !this.props.isUserEmailFormatInvalid &&
         user.roles?.length &&
         user.districts?.length > 0 &&
         user.language
@@ -263,6 +264,7 @@ const mapStateToProps = (state) => ({
   isUserNameValid: state.admin.validationFields?.username?.isValid,
   isUserEmailValid: state.admin.validationFields?.userEmail?.isValid,
   usernameLength: state.admin?.usernameLength,
+  isUserEmailFormatInvalid: state.admin.validationFields?.userEmailFormat?.isInvalid,
 });
 
 const mapDispatchToProps = (dispatch) =>

--- a/src/components/UserMasterPanel.js
+++ b/src/components/UserMasterPanel.js
@@ -1,5 +1,5 @@
 import React, { useEffect } from "react";
-import { connect } from "react-redux";
+import { connect, useDispatch } from "react-redux";
 
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { Grid, Divider, Typography } from "@material-ui/core";
@@ -11,7 +11,7 @@ import {
   PublishedComponent,
   ValidatedTextInput,
 } from "@openimis/fe-core";
-import { CLAIM_ADMIN_USER_TYPE, ENROLMENT_OFFICER_USER_TYPE } from "../constants";
+import { CLAIM_ADMIN_USER_TYPE, ENROLMENT_OFFICER_USER_TYPE, EMAIL_REGEX_PATTERN } from "../constants";
 import {
   usernameValidationCheck,
   usernameValidationClear,
@@ -19,6 +19,7 @@ import {
   userEmailValidationCheck,
   userEmailValidationClear,
   setUserEmailValid,
+  saveEmailFormatValidity,
 } from "../actions";
 
 const styles = (theme) => ({
@@ -48,12 +49,14 @@ const UserMasterPanel = (props) => {
     usernameValidationError,
     isUserEmailValid,
     isUserEmailValidating,
+    isUserEmailFormatInvalid,
     emailValidationError,
     savedUsername,
     savedUserEmail,
     usernameLength,
   } = props;
   const { formatMessage } = useTranslations("admin", modulesManager);
+  const dispatch = useDispatch();
 
   const shouldValidateUsername = (inputValue) => {
     const shouldBeValidated = inputValue !== savedUsername;
@@ -67,6 +70,25 @@ const UserMasterPanel = (props) => {
     }
     return shouldBeValidated;
   };
+
+  const checkEmailFormatValidity = (emailInput) => {
+    if (!emailInput) return false;
+
+    const isEmailInvalid = !EMAIL_REGEX_PATTERN.test(emailInput);
+
+    return isEmailInvalid;
+  };
+
+  const handleEmailChange = (email) => {
+    const isFormatValid = checkEmailFormatValidity(email);
+    dispatch(saveEmailFormatValidity(isFormatValid));
+
+    onEditedChanged({ ...edited, email });
+  };
+
+  useEffect(() => {
+    handleEmailChange(edited?.email);
+  }, []);
 
   return (
     <Grid container direction="row">
@@ -123,6 +145,7 @@ const UserMasterPanel = (props) => {
             isValid={isUserEmailValid}
             isValidating={isUserEmailValidating}
             validationError={emailValidationError}
+            invalidValueFormat={isUserEmailFormatInvalid}
             action={userEmailValidationCheck}
             clearAction={userEmailValidationClear}
             setValidAction={setUserEmailValid}
@@ -131,12 +154,13 @@ const UserMasterPanel = (props) => {
             label="user.email"
             type="email"
             codeTakenLabel="user.emailAlreadyTaken"
+            invalidValueFormatLabel="user.emailFormatInvalid"
             required={
               obligatoryUserFields?.email === "M" ||
               (edited.userTypes?.includes(ENROLMENT_OFFICER_USER_TYPE) && obligatoryEOFields?.email === "M")
             }
             value={edited?.email ?? ""}
-            onChange={(email) => onEditedChanged({ ...edited, email })}
+            onChange={(email) => handleEmailChange(email)}
           />
         </Grid>
       )}
@@ -263,6 +287,7 @@ const mapStateToProps = (state) => ({
   isUserEmailValidating: state.admin.validationFields?.userEmail?.isValidating,
   emailValidationError: state.admin.validationFields?.userEmail?.validationError,
   savedUserEmail: state.admin?.user?.email,
+  isUserEmailFormatInvalid: state.admin.validationFields?.userEmailFormat?.isInvalid,
 });
 
 export default withModulesManager(connect(mapStateToProps)(withTheme(withStyles(styles)(UserMasterPanel))));

--- a/src/constants.js
+++ b/src/constants.js
@@ -22,7 +22,9 @@ export const CLAIM_ADMIN_USER_TYPE = "CLAIM_ADMIN";
 export const CLAIM_ADMIN_IS_SYSTEM = 256;
 export const MODULE_NAME = "user";
 
-export const EMAIL_REGEX_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+// https://html.spec.whatwg.org/multipage/input.html#valid-e-mail-address
+export const EMAIL_REGEX_PATTERN =
+  /^[a-zA-Z0-9.!#$%&'*+/=?^_`{|}~-]+@[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?(?:\.[a-zA-Z0-9](?:[a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?)*$/;
 
 export const USER_TYPES = (rights) => {
   const baseTypes = [INTERACTIVE_USER_TYPE];

--- a/src/constants.js
+++ b/src/constants.js
@@ -22,6 +22,8 @@ export const CLAIM_ADMIN_USER_TYPE = "CLAIM_ADMIN";
 export const CLAIM_ADMIN_IS_SYSTEM = 256;
 export const MODULE_NAME = "user";
 
+export const EMAIL_REGEX_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
 export const USER_TYPES = (rights) => {
   const baseTypes = [INTERACTIVE_USER_TYPE];
   if (rights.includes(RIGHT_ENROLMENTOFFICER)) {

--- a/src/reducer.js
+++ b/src/reducer.js
@@ -408,6 +408,16 @@ function reducer(
           },
         },
       };
+    case "USER_EMAIL_FORMAT_VALIDATION_CHECK":
+      return {
+        ...state,
+        validationFields: {
+          ...state.validationFields,
+          userEmailFormat: {
+            isInvalid: action.payload?.data?.isFormatInvalid,
+          },
+        },
+      };
     case "USERNAME_LENGTH_FIELDS_REQ":
       return {
         ...state,

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -23,6 +23,7 @@
   "admin.user.addNewUserTooltip": "Add new user",
   "admin.user.usernameAlreadyTaken": "Username already in use",
   "admin.user.emailAlreadyTaken": "User email already in use",
+  "admin.user.emailFormatInvalid": "Invalid email format",
   "admin.user.createUser.mutationLabel": "Create user",
   "admin.user.deleteDialog.message": "Are you sure you want to delete this user?",
   "admin.user.deleteDialog.title": "Delete user",


### PR DESCRIPTION
**[CORE PR MERGE REQUIRED](https://github.com/openimis/openimis-fe-core_js/pull/112)**

[OTC-887](https://openimis.atlassian.net/browse/OTC-887)

Changes:
- Possibility to display information that value format is invalid implemented.
- If the email format is invalid, user will get an information about that and it is not possible to save.
- New translation key has been added to the Lokalise.

[OTC-887]: https://openimis.atlassian.net/browse/OTC-887?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ