### PR TITLE
OP-1725: remove null options

### DIFF
--- a/src/components/UserMasterPanel.js
+++ b/src/components/UserMasterPanel.js
@@ -264,7 +264,7 @@ const UserMasterPanel = (props) => {
           label="user.language"
           readOnly={readOnly}
           required
-          withNull
+          withNull={false}
           nullLabel={formatMessage("UserMasterPanel.language.null")}
           value={edited.language ?? ""}
           onChange={(language) => onEditedChanged({ ...edited, language })}


### PR DESCRIPTION
[OP-1725](https://openimis.atlassian.net/browse/OP-1725)

Changes:
- Remove the 'none/null' option from the dropdown menu in the form.

[OP-1725]: https://openimis.atlassian.net/browse/OP-1725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ