### PR TITLE
hotfix: change condition

### DIFF
--- a/src/components/AdminMainMenu.js
+++ b/src/components/AdminMainMenu.js
@@ -39,12 +39,14 @@ class AdminMainMenu extends Component {
     const { rights } = this.props;
     const entries = [];
 
-    if (this.isWorker && rights.includes(RIGHT_USERS)) {
-      entries.push({
-        text: formatMessage(this.props.intl, "admin", "menu.users"),
-        icon: <Person />,
-        route: "/admin/users",
-      });
+    if (this.isWorker) {
+      if (rights.includes(RIGHT_USERS)) {
+        entries.push({
+          text: formatMessage(this.props.intl, "admin", "menu.users"),
+          icon: <Person />,
+          route: "/admin/users",
+        });
+      }
 
       if (!entries.length) return null;
 


### PR DESCRIPTION
If 'isWorker' true and user do not have proper rights, hide 'Administration' entry.