### PR TITLE
hide some components from admin user management that were specific to a particular module

### DIFF
--- a/src/components/UserFilter.js
+++ b/src/components/UserFilter.js
@@ -1,5 +1,6 @@
 import React, { Component } from "react";
 import _debounce from "lodash/debounce";
+import { connect } from "react-redux";
 
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { injectIntl } from "react-intl";
@@ -13,7 +14,7 @@ import {
   TextInput,
   formatMessage,
 } from "@openimis/fe-core";
-import { DEFAULT } from "../constants";
+import { DEFAULT, RIGHT_HEALTHFACILITIES } from "../constants";
 
 const styles = (theme) => ({
   dialogTitle: theme.dialog.title,
@@ -222,7 +223,7 @@ class UserFilter extends Component {
   );
 
   render() {
-    const { classes, filters, onChangeFilters, intl } = this.props;
+    const { classes, filters, onChangeFilters, intl, rights } = this.props;
     const { locationFilters, currentUserType, currentUserRoles, selectedDistrict } = this.state;
     return (
       <section className={classes.form}>
@@ -253,29 +254,30 @@ class UserFilter extends Component {
               </Grid>
             }
           />
-          <ControlledField
-            module="admin"
-            id="userFilter.healthFacility"
-            field={
-              <Grid item xs={3} className={classes.item}>
-                <PublishedComponent
-                  pubRef="location.HealthFacilityPicker"
-                  withNull={true}
-                  value={this.filterValue("healthFacilityId") || ""}
-                  district={selectedDistrict}
-                  onChange={(v) => {
-                    onChangeFilters([
-                      {
-                        id: "healthFacility",
-                        value: v,
-                        filter: v ? `healthFacilityId: ${decodeId(v.id)}` : null,
-                      },
-                    ]);
-                  }}
-                />
-              </Grid>
-            }
-          />
+          { rights.includes(RIGHT_HEALTHFACILITIES) && (<ControlledField
+              module="admin"
+              id="userFilter.healthFacility"
+              field={
+                <Grid item xs={3} className={classes.item}>
+                  <PublishedComponent
+                    pubRef="location.HealthFacilityPicker"
+                    withNull={true}
+                    value={this.filterValue("healthFacilityId") || ""}
+                    district={selectedDistrict}
+                    onChange={(v) => {
+                      onChangeFilters([
+                        {
+                          id: "healthFacility",
+                          value: v,
+                          filter: v ? `healthFacilityId: ${decodeId(v.id)}` : null,
+                        },
+                      ]);
+                    }}
+                  />
+                </Grid>
+              }
+            />
+          )}
         </Grid>
         <Grid container>
           <Grid item xs={12}>
@@ -439,4 +441,9 @@ class UserFilter extends Component {
   }
 }
 
-export default withModulesManager(injectIntl(withTheme(withStyles(styles)(UserFilter))));
+const mapStateToProps = (state) => ({
+  rights: state.core?.user?.i_user?.rights ?? [],
+  module: state.core?.savedPagination?.module,
+});
+
+export default withModulesManager(connect(mapStateToProps)(injectIntl(withTheme(withStyles(styles)(UserFilter)))));

--- a/src/components/UserForm.js
+++ b/src/components/UserForm.js
@@ -18,7 +18,7 @@ import {
   coreConfirm,
   parseData,
 } from "@openimis/fe-core";
-import { CLAIM_ADMIN_USER_TYPE, ENROLMENT_OFFICER_USER_TYPE, INTERACTIVE_USER_TYPE, RIGHT_USERS } from "../constants";
+import { CLAIM_ADMIN_USER_TYPE, ENROLMENT_OFFICER_USER_TYPE, INTERACTIVE_USER_TYPE, RIGHT_USERS, RIGHT_CLAIMADMINISTRATOR } from "../constants";
 import EnrolmentOfficerFormPanel from "./EnrolmentOfficerFormPanel";
 import ClaimAdministratorFormPanel from "./ClaimAdministratorFormPanel";
 import {
@@ -251,7 +251,7 @@ class UserForm extends Component {
             readOnly={readOnly || isInMutation || user?.validityTo}
             actions={actions}
             HeadPanel={UserMasterPanel}
-            Panels={[EnrolmentOfficerFormPanel, ClaimAdministratorFormPanel]}
+            Panels={[EnrolmentOfficerFormPanel, ...(rights.includes(RIGHT_CLAIMADMINISTRATOR) ? [ClaimAdministratorFormPanel] : []) ]}
             user={user}
             onEditedChanged={this.onEditedChanged}
             canSave={!user.validityTo && this.canSave}

--- a/src/components/UserMasterPanel.js
+++ b/src/components/UserMasterPanel.js
@@ -16,7 +16,7 @@ import {
   passwordGenerator,
   validatePassword,
 } from "@openimis/fe-core";
-import { CLAIM_ADMIN_USER_TYPE, ENROLMENT_OFFICER_USER_TYPE, EMAIL_REGEX_PATTERN, DEFAULT } from "../constants";
+import { CLAIM_ADMIN_USER_TYPE, ENROLMENT_OFFICER_USER_TYPE, EMAIL_REGEX_PATTERN, DEFAULT, RIGHT_HEALTHFACILITIES } from "../constants";
 import {
   usernameValidationCheck,
   usernameValidationClear,
@@ -62,6 +62,7 @@ const UserMasterPanel = (props) => {
     savedUserEmail,
     usernameLength,
     passwordPolicy,
+    rights,
   } = props;
   const { formatMessage, formatMessageWithValues } = useTranslations("admin", modulesManager);
   const dispatch = useDispatch();
@@ -240,17 +241,18 @@ const UserMasterPanel = (props) => {
             />
           </Grid>
         )}
-      <Grid item xs={4} className={classes.item}>
-        <PublishedComponent
-          pubRef="location.HealthFacilityPicker"
-          value={edited?.healthFacility}
-          district={edited.districts}
-          module="admin"
-          readOnly={readOnly}
-          required={edited.userTypes.includes(CLAIM_ADMIN_USER_TYPE)}
-          onChange={(healthFacility) => onEditedChanged({ ...edited, healthFacility })}
-        />
-      </Grid>
+      { rights.includes(RIGHT_HEALTHFACILITIES) && (<Grid item xs={4} className={classes.item}>
+          <PublishedComponent
+            pubRef="location.HealthFacilityPicker"
+            value={edited?.healthFacility}
+            district={edited.districts}
+            module="admin"
+            readOnly={readOnly}
+            required={edited.userTypes.includes(CLAIM_ADMIN_USER_TYPE)}
+            onChange={(healthFacility) => onEditedChanged({ ...edited, healthFacility })}
+          />
+        </Grid>
+      )}
       <Grid item xs={6} className={classes.item}>
         <PublishedComponent
           pubRef="admin.UserRolesPicker"
@@ -366,6 +368,7 @@ const UserMasterPanel = (props) => {
 };
 
 const mapStateToProps = (state) => ({
+  rights: state.core?.user?.i_user?.rights ?? [],
   isUsernameValid: state.admin.validationFields?.username?.isValid,
   isUsernameValidating: state.admin.validationFields?.username?.isValidating,
   usernameValidationError: state.admin.validationFields?.username?.validationError,


### PR DESCRIPTION
**Context:**

In the fe-admin module there are some components that are particular to some modules and should only be shown if those modules access is given to the user. 

For example "Health Facility" filter and picker field for users should only be shown if the logged in user have permissions to see the "Health Facilities". 

Screenshots highlighting the component in question:-
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/ea1b901e-0d07-4009-92b9-129e720f3ce6">
<img width="1511" alt="image" src="https://github.com/user-attachments/assets/c5ffa97c-bd6f-49b1-9fbf-0abf52e84c23">

Similarly to the "Health Module" we have a component about "Claim" which should only be shown if the "Claim" module permission is available. 
<img width="1510" alt="image" src="https://github.com/user-attachments/assets/f8e332f6-fb3b-4722-b867-86882900bf76">

I have updated the code to hide these optional components when relevant permissions aren't available. 