### PR TITLE
Feature/op 2042: fix password validation

### DIFF
--- a/src/components/UserForm.js
+++ b/src/components/UserForm.js
@@ -18,13 +18,13 @@ import {
   coreConfirm,
   parseData,
 } from "@openimis/fe-core";
-import { 
-  CLAIM_ADMIN_USER_TYPE, 
-  ENROLMENT_OFFICER_USER_TYPE, 
-  INTERACTIVE_USER_TYPE, 
-  RIGHT_USERS, 
-  RIGHT_CLAIMADMINISTRATOR, 
-  RIGHT_ENROLMENTOFFICER 
+import {
+  CLAIM_ADMIN_USER_TYPE,
+  ENROLMENT_OFFICER_USER_TYPE,
+  INTERACTIVE_USER_TYPE,
+  RIGHT_USERS,
+  RIGHT_CLAIMADMINISTRATOR,
+  RIGHT_ENROLMENTOFFICER
 } from "../constants";
 import EnrolmentOfficerFormPanel from "./EnrolmentOfficerFormPanel";
 import ClaimAdministratorFormPanel from "./ClaimAdministratorFormPanel";
@@ -51,8 +51,8 @@ const setupState = (props) => ({
   isLocked: false,
   user: !props?.userId
     ? {
-        userTypes: [INTERACTIVE_USER_TYPE],
-      }
+      userTypes: [INTERACTIVE_USER_TYPE],
+    }
     : props.user,
   isSaved: false,
   reset: 0,
@@ -177,7 +177,11 @@ class UserForm extends Component {
       )
     )
       return false;
+
+    if (!user.id && !user.password) return false;
     if (user.password && user.password !== user.confirmPassword) return false;
+    if (user.password && !user.isPasswordValid) return false;
+
     if (user.userTypes?.includes(CLAIM_ADMIN_USER_TYPE) && !user.healthFacility) return false;
     if (user.userTypes?.includes(ENROLMENT_OFFICER_USER_TYPE) && !user.officerVillages) return false;
     if (
@@ -259,8 +263,8 @@ class UserForm extends Component {
             actions={actions}
             HeadPanel={UserMasterPanel}
             Panels={[
-              ...(rights.includes(RIGHT_ENROLMENTOFFICER) ? [EnrolmentOfficerFormPanel] : []), 
-              ...(rights.includes(RIGHT_CLAIMADMINISTRATOR) ? [ClaimAdministratorFormPanel] : []) 
+              ...(rights.includes(RIGHT_ENROLMENTOFFICER) ? [EnrolmentOfficerFormPanel] : []),
+              ...(rights.includes(RIGHT_CLAIMADMINISTRATOR) ? [ClaimAdministratorFormPanel] : [])
             ]}
             user={user}
             onEditedChanged={this.onEditedChanged}

--- a/src/components/UserMasterPanel.js
+++ b/src/components/UserMasterPanel.js
@@ -109,7 +109,8 @@ const UserMasterPanel = (props) => {
   const [passwordFeedback, setPasswordFeedback] = useState("");
   const [passwordScore, setPasswordScore] = useState(0);
   const [showPassword, setShowPassword] = useState(false);
-  const IS_PASSWORD_SECURED = passwordScore >= 2;
+  const REQUIRED_SECURITY_LEVEL = 2;
+  let IS_PASSWORD_SECURED = passwordScore >= REQUIRED_SECURITY_LEVEL;
   const handleClickShowPassword = () => setShowPassword((show) => !show);
 
   const handleMouseDownPassword = (event) => {
@@ -120,7 +121,8 @@ const UserMasterPanel = (props) => {
     const { feedback, score } = validatePassword(password, passwordPolicy, formatMessage, formatMessageWithValues);
     setPasswordFeedback(feedback);
     setPasswordScore(score);
-    onEditedChanged({ ...edited, password });
+    IS_PASSWORD_SECURED = score >= REQUIRED_SECURITY_LEVEL;
+    onEditedChanged({ ...edited, password, isPasswordValid: IS_PASSWORD_SECURED });
   };
 
   const generatePassword = () => {
@@ -132,7 +134,8 @@ const UserMasterPanel = (props) => {
       isSpecialSymbolRequired: true,
     });
     const generatedPassword = passwordGenerator(passwordGeneratorOptions);
-    onEditedChanged({ ...edited, password: generatedPassword, confirmPassword: generatedPassword });
+    IS_PASSWORD_SECURED = true;
+    onEditedChanged({ ...edited, password: generatedPassword, confirmPassword: generatedPassword, isPasswordValid: IS_PASSWORD_SECURED });
   };
 
   const renderLastNameField = (edited, classes, readOnly) => (
@@ -241,17 +244,17 @@ const UserMasterPanel = (props) => {
             />
           </Grid>
         )}
-      { rights.includes(RIGHT_HEALTHFACILITIES) && (<Grid item xs={4} className={classes.item}>
-          <PublishedComponent
-            pubRef="location.HealthFacilityPicker"
-            value={edited?.healthFacility}
-            district={edited.districts}
-            module="admin"
-            readOnly={readOnly}
-            required={edited.userTypes.includes(CLAIM_ADMIN_USER_TYPE)}
-            onChange={(healthFacility) => onEditedChanged({ ...edited, healthFacility })}
-          />
-        </Grid>
+      {rights.includes(RIGHT_HEALTHFACILITIES) && (<Grid item xs={4} className={classes.item}>
+        <PublishedComponent
+          pubRef="location.HealthFacilityPicker"
+          value={edited?.healthFacility}
+          district={edited.districts}
+          module="admin"
+          readOnly={readOnly}
+          required={edited.userTypes.includes(CLAIM_ADMIN_USER_TYPE)}
+          onChange={(healthFacility) => onEditedChanged({ ...edited, healthFacility })}
+        />
+      </Grid>
       )}
       <Grid item xs={6} className={classes.item}>
         <PublishedComponent
@@ -344,6 +347,7 @@ const UserMasterPanel = (props) => {
           readOnly={readOnly}
           value={edited.confirmPassword}
           onChange={(confirmPassword) => onEditedChanged({ ...edited, confirmPassword })}
+          error={edited?.password !== edited?.confirmPassword}
           endAdornment={
             <InputAdornment position="end">
               <IconButton


### PR DESCRIPTION
Ticket:
https://openimis.atlassian.net/browse/OP-2042

Changes:
- password validation does not allow to save after edge case 'Create strong password -> delete it'
- User edit panel allows to skip the password for editing user (if there is no user.id). So it will affect only update user mutation

Tests:
1. Case 'Create strong password -> delete it' does not work anymore, so validation works as expected
2. Admin was able to update user without providing password