### PR TITLE
fix UserForm saving...OP-1611

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -56,7 +56,6 @@ export const mapQueriesUserToStore = (u) => {
     u.email = u.email ?? u.claimAdmin.emailId;
     u.phoneNumber = u.claimAdmin.phone;
     u.birthDate = u.claimAdmin.dob;
-    u.healthFacility = u.claimAdmin.healthFacility;
   }
   if (u.officer) {
     u.hasLogin = u.hasLogin || u.officer.hasLogin;


### PR DESCRIPTION
Initially, an Admin user was assigned a health facility. We removed it and saved the changes. The success message appears on the sidebar, but when refreshing the page or returning to it, the health facility is still there.

This happens because the mapQueriesUserToStore function forces user.healthFacilities to take the value of the old user.claimAdmin.healthFacilities when user.healthFacilities is null.

We prevented this to fix the issue.