### PR TITLE
set text beside icons OP-2578

### DIFF
--- a/src/components/UserSearcher.js
+++ b/src/components/UserSearcher.js
@@ -148,15 +148,21 @@ class UserSearcher extends Component {
       (u) => (
         <div className={this.props.classes.horizontalButtonContainer}>
           <Tooltip title={formatMessage(this.props.intl, "admin.user", "openNewTab")}>
-            <IconButton onClick={() => this.props.onDoubleClick(u, true)}>
-              <TabIcon />
-            </IconButton>
+            <div>
+              <IconButton onClick={() => this.props.onDoubleClick(u, true)}>
+                <TabIcon />
+              </IconButton>
+              {formatMessage(this.props.intl, "admin.user", "openInNewTab.buttonText")}
+            </div>
           </Tooltip>
           {this.props.rights.includes(RIGHT_USER_DELETE) && u.validityTo ? null : (
             <Tooltip title={formatMessage(this.props.intl, "admin.user", "deleteUser.tooltip")}>
-              <IconButton onClick={() => this.setState({ deleteUser: u })} disabled={u.validityTo}>
-                <DeleteIcon />
-              </IconButton>
+              <div>
+                <IconButton onClick={() => this.setState({ deleteUser: u })} disabled={u.validityTo}>
+                  <DeleteIcon />
+                </IconButton>
+                {formatMessage(this.props.intl, "admin.user", "deleteUser.buttonText")}
+              </div>
             </Tooltip>
           )}
         </div>

--- a/src/components/UserSearcher.js
+++ b/src/components/UserSearcher.js
@@ -3,7 +3,7 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
 
-import { IconButton, Tooltip } from "@material-ui/core";
+import { Button, Tooltip } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { Tab as TabIcon, Delete as DeleteIcon } from "@material-ui/icons";
 
@@ -148,21 +148,15 @@ class UserSearcher extends Component {
       (u) => (
         <div className={this.props.classes.horizontalButtonContainer}>
           <Tooltip title={formatMessage(this.props.intl, "admin.user", "openNewTab")}>
-            <div>
-              <IconButton onClick={() => this.props.onDoubleClick(u, true)}>
-                <TabIcon />
-              </IconButton>
-              {formatMessage(this.props.intl, "admin.user", "openInNewTab.buttonText")}
-            </div>
+            <Button startIcon={<TabIcon />} onClick={() => this.props.onDoubleClick(u, true)}>
+              {formatMessage(this.props.intl, "admin.user", "openNewTab.buttonText")}
+            </Button>
           </Tooltip>
           {this.props.rights.includes(RIGHT_USER_DELETE) && u.validityTo ? null : (
             <Tooltip title={formatMessage(this.props.intl, "admin.user", "deleteUser.tooltip")}>
-              <div>
-                <IconButton onClick={() => this.setState({ deleteUser: u })} disabled={u.validityTo}>
-                  <DeleteIcon />
-                </IconButton>
+              <Button startIcon={<DeleteIcon />} onClick={() => this.setState({ deleteUser: u })} disabled={u.validityTo}>
                 {formatMessage(this.props.intl, "admin.user", "deleteUser.buttonText")}
-              </div>
+              </Button>
             </Tooltip>
           )}
         </div>

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -29,6 +29,8 @@
   "admin.user.deleteDialog.title": "Delete user",
   "admin.user.deleteDialog.yes.button": "Yes",
   "admin.user.deleteUser.tooltip": "Delete user",
+  "admin.user.deleteUser.buttonText": "Delete",
+  "admin.user.openInNewTab.buttonText": "Open in new tab",
   "admin.user.deleteUserDialog.message": "Are you sure you want to delete this user?",
   "admin.user.dob": "Birth date",
   "admin.user.dobFrom": "Birth date from",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -39,6 +39,7 @@
   "admin.user.districts": "Districts",
   "admin.user.regions": "Regions",
   "admin.user.lastName": "Last name",
+  "admin.user.openNewTab.buttonText": "Open",
   "admin.user.language": "Interface Language",
   "admin.user.openNewTab": "Open in new tab",
   "admin.user.otherNames": "Other names",


### PR DESCRIPTION
Added descriptive text next to icon-only buttons to improve usability and accessibility.
According to [WCAG 2.1](https://www.w3.org/TR/WCAG21/) and usability best practices, relying on icons alone can create confusion since many icons do not have a universal meaning. By adding short descriptive labels, the interface becomes more intuitive, accessible to all users, and compliant with accessibility standards.

<img width="1854" height="938" alt="Capture d’écran du 2025-09-27 18-46-39" src="https://github.com/user-attachments/assets/ba1d4254-0cba-41c2-88c9-8f21c20bb90b" />
