### PR TITLE
feat: programs in fe-admin

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -14,7 +14,7 @@ const USER_SUMMARY_PROJECTION = [
   "id",
   "username",
   "officer{id,dob,phone,lastName,otherNames,email}",
-  "iUser{id,phone,lastName,otherNames,email,roles{id,name}}",
+  "iUser{id,phone,lastName,otherNames,email,roles{id,name},programs{id,uuid,code,name,validityFrom}}",
   "claimAdmin{id,phone,lastName,otherNames,emailId,dob}",
   "validityTo",
   "clientMutationId",

--- a/src/actions.js
+++ b/src/actions.js
@@ -14,7 +14,7 @@ const USER_SUMMARY_PROJECTION = [
   "id",
   "username",
   "officer{id,dob,phone,lastName,otherNames,email}",
-  "iUser{id,phone,lastName,otherNames,email,roles{id,name},programs{id,uuid,code,name,validityFrom}}",
+  "iUser{id,phone,lastName,otherNames,email,roles{id,name}}",
   "claimAdmin{id,phone,lastName,otherNames,emailId,dob}",
   "validityTo",
   "clientMutationId",
@@ -220,6 +220,7 @@ export function fetchUser(mm, userId, clientMutationId) {
               lastName
               otherNames
               roles { id name isSystem}
+              programSet { edges{node{id idProgram nameProgram validityDateFrom}}}
               healthFacility ${mm.getProjection("location.HealthFacilityPicker.projection")}
               validityFrom
               validityTo

--- a/src/components/AdminMainMenu.js
+++ b/src/components/AdminMainMenu.js
@@ -12,6 +12,7 @@ import {
   People,
   PinDrop,
   Tune,
+  FormatAlignLeft
 } from "@material-ui/icons";
 import { formatMessage, MainMenuContribution, withModulesManager } from "@openimis/fe-core";
 import {
@@ -21,6 +22,7 @@ import {
   RIGHT_PRICELISTMI,
   RIGHT_MEDICALSERVICES,
   RIGHT_MEDICALITEMS,
+  RIGHT_PROGRAMS,
   // RIGHT_ENROLMENTOFFICER,
   // RIGHT_CLAIMADMINISTRATOR,
   RIGHT_USERS,
@@ -34,6 +36,7 @@ class AdminMainMenu extends Component {
   constructor(props) {
     super(props);
     this.isWorker = props.modulesManager.getConf("fe-core", "isWorker", false);
+    this.isProgramAvailable = props.modulesManager.getConf("fe-core", "isProgramAvailable", false);
   }
 
   render() {
@@ -84,6 +87,15 @@ class AdminMainMenu extends Component {
         route: "/location/healthFacilities",
         withDivider: true,
         id: "admin.healthFacilities",
+      });
+    }
+    if (this.isProgramAvailable && RIGHT_PROGRAMS) {
+        entries.push({
+        text: formatMessage(this.props.intl, "admin", "menu.programs"),
+        icon: <FormatAlignLeft />,
+        route: "/program/programs",
+        id: "admin.programs",
+        withDivider: true,
       });
     }
     if (rights.includes(RIGHT_PRICELISTMS)) {

--- a/src/components/AdminMainMenu.js
+++ b/src/components/AdminMainMenu.js
@@ -22,7 +22,6 @@ import {
   RIGHT_PRICELISTMI,
   RIGHT_MEDICALSERVICES,
   RIGHT_MEDICALITEMS,
-  RIGHT_PROGRAMS,
   // RIGHT_ENROLMENTOFFICER,
   // RIGHT_CLAIMADMINISTRATOR,
   RIGHT_USERS,
@@ -89,7 +88,7 @@ class AdminMainMenu extends Component {
         id: "admin.healthFacilities",
       });
     }
-    if (this.isProgramAvailable && RIGHT_PROGRAMS) {
+    if (this.isProgramAvailable) {
         entries.push({
         text: formatMessage(this.props.intl, "admin", "menu.programs"),
         icon: <FormatAlignLeft />,

--- a/src/components/UserMasterPanel.js
+++ b/src/components/UserMasterPanel.js
@@ -272,11 +272,13 @@ const UserMasterPanel = (props) => {
         <Grid item xs={4} className={classes.item}>
           <PublishedComponent
             pubRef="program.ProgramPicker"
-            module="admin"
-            label="program.ProgramPicker.placeholder"
-            value={edited?.program}
+            name="program"
+            label={formatMessage("user.programPicker.label")}
+            placeholder={formatMessage("user.programPicker.placeholder")}
+            value={edited?.programs ?? []}
+            multiple={true}
             readOnly={readOnly}
-            onChange={(program) => onEditedChanged({ ...edited, program })}
+            onChange={(programs) => onEditedChanged({ ...edited, programs })}
           />
         </Grid>
       )}

--- a/src/components/UserMasterPanel.js
+++ b/src/components/UserMasterPanel.js
@@ -67,6 +67,8 @@ const UserMasterPanel = (props) => {
   const { formatMessage, formatMessageWithValues } = useTranslations("admin", modulesManager);
   const dispatch = useDispatch();
 
+  const isProgramAvailable = modulesManager.getConf("fe-core", "isProgramAvailable", true);
+
   useEffect(() => {
     dispatch(fetchPasswordPolicy());
   }, [dispatch]);
@@ -266,7 +268,19 @@ const UserMasterPanel = (props) => {
           onChange={(roles) => onEditedChanged({ ...edited, roles })}
         />
       </Grid>
-      <Grid item xs={2} className={classes.item}>
+      {isProgramAvailable && (
+        <Grid item xs={4} className={classes.item}>
+          <PublishedComponent
+            pubRef="program.ProgramPicker"
+            module="admin"
+            label="program.ProgramPicker.placeholder"
+            value={edited?.program}
+            readOnly={readOnly}
+            onChange={(program) => onEditedChanged({ ...edited, program })}
+          />
+        </Grid>
+      )}
+      <Grid item xs={6} className={classes.item}>
         <PublishedComponent
           pubRef="location.LocationPicker"
           locationLevel={0}

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,10 +9,6 @@ export const RIGHT_CLAIMADMINISTRATOR = 121601;
 export const RIGHT_PAYERS = 121801;
 export const RIGHT_LOCATIONS = 121901;
 
-export const RIGHT_PROGRAMS = 121701;
-export const RIGHT_PROGRAM_DELETE = 121701;
-export const RIGHT_PROGRAM_ADD = 121702;
-
 export const RIGHT_USERS = 121701;
 export const RIGHT_USER_SEARCH = 121701;
 export const RIGHT_USER_ADD = 121702;

--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,10 @@ export const RIGHT_CLAIMADMINISTRATOR = 121601;
 export const RIGHT_PAYERS = 121801;
 export const RIGHT_LOCATIONS = 121901;
 
+export const RIGHT_PROGRAMS = 121701;
+export const RIGHT_PROGRAM_DELETE = 121701;
+export const RIGHT_PROGRAM_ADD = 121702;
+
 export const RIGHT_USERS = 121701;
 export const RIGHT_USER_SEARCH = 121701;
 export const RIGHT_USER_ADD = 121702;

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -49,6 +49,7 @@
   "admin.user.confirmNewPassword": "Confirm Password",
   "admin.user.generatePassword": "Generate Password",
   "program.ProgramPicker.placeholder": "Select Program",
+  "admin.menu.programs": "Programs",
   "admin.user.phone": "Phone",
   "admin.user.updateUser.mutationLabel": "Update user",
   "admin.user.userRoles.placeholder": "Select User Role(s)",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -48,6 +48,7 @@
   "admin.user.newPassword": "New Password",
   "admin.user.confirmNewPassword": "Confirm Password",
   "admin.user.generatePassword": "Generate Password",
+  "program.ProgramPicker.placeholder": "Select Program",
   "admin.user.phone": "Phone",
   "admin.user.updateUser.mutationLabel": "Update user",
   "admin.user.userRoles.placeholder": "Select User Role(s)",

--- a/src/translations/en.json
+++ b/src/translations/en.json
@@ -48,7 +48,7 @@
   "admin.user.newPassword": "New Password",
   "admin.user.confirmNewPassword": "Confirm Password",
   "admin.user.generatePassword": "Generate Password",
-  "program.ProgramPicker.placeholder": "Select Program",
+  "admin.ProgramPicker.placeholder": "Select Program",
   "admin.menu.programs": "Programs",
   "admin.user.phone": "Phone",
   "admin.user.updateUser.mutationLabel": "Update user",

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,7 +48,7 @@ export const mapQueriesUserToStore = (u) => {
     u.language = u.iUser.languageId;
     u.roles = u.iUser.roles;
     u.districts = u.iUser.districts.map((d) => d.location);
-    u.programs = u.iUser.programs;
+    u.programs = u.iUser.programSet.edges.map((p) => p.node);
   }
   if (u.claimAdmin) {
     u.hasLogin = u.hasLogin || u.claimAdmin.hasLogin;
@@ -73,7 +73,6 @@ export const mapQueriesUserToStore = (u) => {
     u.worksTo = u.officer.worksTo;
     u.location = u.officer.location;
     u.officerVillages = u.officer.officerVillages.map((x) => x.location);
-    u.programs = u.officer.programs;
   }
   return u;
 };
@@ -98,7 +97,7 @@ export const mapUserValuesToInput = (values) => {
     substitutionOfficerId: values.substitutionOfficer?.id ? decodeId(values.substitutionOfficer.id) : null,
     worksTo: values.worksTo,
     villageIds: values.officerVillages?.map((location) => decodeId(location.id)),
-    programId: values.program ? decodeId(values.program.id) : null,
+    programs: values.programs.map((p) => decodeId(p.id)),  
   };
   return input;
 };

--- a/src/utils.js
+++ b/src/utils.js
@@ -48,6 +48,7 @@ export const mapQueriesUserToStore = (u) => {
     u.language = u.iUser.languageId;
     u.roles = u.iUser.roles;
     u.districts = u.iUser.districts.map((d) => d.location);
+    u.programs = u.iUser.programs;
   }
   if (u.claimAdmin) {
     u.hasLogin = u.hasLogin || u.claimAdmin.hasLogin;
@@ -57,6 +58,7 @@ export const mapQueriesUserToStore = (u) => {
     u.phoneNumber = u.claimAdmin.phone;
     u.birthDate = u.claimAdmin.dob;
     u.healthFacility = u.claimAdmin.healthFacility;
+    u.programs = u.claimAdmin.programs;
   }
   if (u.officer) {
     u.hasLogin = u.hasLogin || u.officer.hasLogin;
@@ -71,6 +73,7 @@ export const mapQueriesUserToStore = (u) => {
     u.worksTo = u.officer.worksTo;
     u.location = u.officer.location;
     u.officerVillages = u.officer.officerVillages.map((x) => x.location);
+    u.programs = u.officer.programs;
   }
   return u;
 };
@@ -95,6 +98,7 @@ export const mapUserValuesToInput = (values) => {
     substitutionOfficerId: values.substitutionOfficer?.id ? decodeId(values.substitutionOfficer.id) : null,
     worksTo: values.worksTo,
     villageIds: values.officerVillages?.map((location) => decodeId(location.id)),
+    programId: values.program ? decodeId(values.program.id) : null,
   };
   return input;
 };


### PR DESCRIPTION
# Description

This PR implements program association for users in the fe-admin module. Adds program field in user creation/editing panel with conditional display based on configuration. Updates GraphQL queries and mutations to include program data for iUser type, this PR allows an user to be associated with one or many pograms.
We also used the same config to display the program's menu entry in AdminMainMenu.js 
The config is :  "fe-core, isProgramAvailable, false"

# Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [x] Requires https://github.com/openimis/openimis-fe_js/pull/215 and https://github.com/openimis/openimis-fe-core_js/pull/298  needs to be merged first before this one
- [ ] Relates to [link to github PR], this needs to be merged before [link to github PR]
- [ ] External reference (e.g., Jira):

## Demo

Upload screenshots/gifs or link to any demo video here.

## Checklist
- [ ] Unit tests added/modified
- [x] I18n / translation handled
