### PR TITLE
feat: remove validity_from/to from user projection

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -221,8 +221,6 @@ export function fetchUser(mm, userId, clientMutationId) {
               otherNames
               roles { id name isSystem}
               healthFacility ${mm.getProjection("location.HealthFacilityPicker.projection")}
-              validityFrom
-              validityTo
               email
               districts: userdistrictSet { location { id name code uuid parent { id code uuid name }}}
             }


### PR DESCRIPTION
# Description

Remove `validityFrom` and `validityTo` from the user's projection.

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
- [ ] Requires [link to github PR], [link to github PR] needs to be merged first before this one
- [x] Relates to [link to github PR], empty db PR
- [ ] External reference (e.g., Jira): **Hotfix**

## Checklist
- [ ] Unit tests added/modified
- [ ] I18n / translation handled
