### PR TITLE
User Searcher fatal error fix

### DIFF
--- a/src/components/UserSearcher.js
+++ b/src/components/UserSearcher.js
@@ -3,7 +3,7 @@ import { bindActionCreators } from "redux";
 import { connect } from "react-redux";
 import { injectIntl } from "react-intl";
 
-import { Button, Tooltip } from "@material-ui/core";
+import { IconButton, Button, Tooltip } from "@material-ui/core";
 import { withTheme, withStyles } from "@material-ui/core/styles";
 import { Tab as TabIcon, Delete as DeleteIcon } from "@material-ui/icons";
 


### PR DESCRIPTION
When visiting user searcher, it would show 500 error as it used to miss IconButton component from material UI core. 