### PR TITLE
fix location filter go when search

### DIFF
--- a/src/components/UserFilter.js
+++ b/src/components/UserFilter.js
@@ -285,7 +285,7 @@ class UserFilter extends Component {
               pubRef="location.DetailedLocationFilter"
               withNull={true}
               filters={filters}
-              onChangeFilters={this.onChangeLocation}
+              onChangeFilters={onChangeFilters}
               anchor="parentLocation"
             />
           </Grid>


### PR DESCRIPTION
# Description

On the release instance, when filtering a user by locality, the selected value disappears when clicking the search button. To fix that i reput the onChangeFilters props in filter component

# Type of Change

- [ ] Feature
- [x] Bug fix
- [ ] Chore (Refactor, Docs, CI/CD)
- [ ] Other, please specify

## Related Issue(s) / Task(s)
No related issues

## Demo

<img width="1430" height="334" alt="Screenshot 2026-04-17 at 10 56 46 AM" src="https://github.com/user-attachments/assets/dbf1b4fb-e98e-41e9-804d-58fa5e1c2a2d" />
